### PR TITLE
Add empty array for '_cacheExports'

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -35,7 +35,7 @@ export class DefinitionProvider {
             this._statusBarItem.text = '$(eye) $(sync)';
             analyzeWorkspace().then((exports) => {
                 this._refreshing = false;
-                this._cachedExports = exports || [];
+                this._cachedExports = exports;
                 this._statusBarItem.text = '$(eye) ' + exports.length;
             }, (err) => {
                 this._refreshing = false;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 export class DefinitionProvider {
 
     private static _instance: DefinitionProvider = new DefinitionProvider();
-    private _cachedExports: IExport[];
+    private _cachedExports: IExport[] = [];
     private _statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
     private _refreshing: boolean = false;
 
@@ -35,7 +35,7 @@ export class DefinitionProvider {
             this._statusBarItem.text = '$(eye) $(sync)';
             analyzeWorkspace().then((exports) => {
                 this._refreshing = false;
-                this._cachedExports = exports;
+                this._cachedExports = exports || [];
                 this._statusBarItem.text = '$(eye) ' + exports.length;
             }, (err) => {
                 this._refreshing = false;


### PR DESCRIPTION
Add initialization for `_cacheExports` and default value in `refreshExports`.

`containsItem` and `toQuickPickItemList` are vulnerable to crash if `_cacheExports` is not initialized or set to an empty array as default in `refreshExports`.

Crash Report:
```
Cannot read property 'length' of undefined: TypeError: Cannot read property 'length' of undefined
    at DefinitionProvider.containsItem (C:\Users\Jimi\.vscode-insiders\extensions\DSKWRK.vscode-generate-getter-setter-0.4.2\out\src\provider.js:52:48)
    at C:\Users\Jimi\.vscode-insiders\extensions\DSKWRK.vscode-generate-getter-setter-0.4.2\out\src\bulb.js:10:56
    at CompleteActionProvider.provideCodeActions (C:\Users\Jimi\.vscode-insiders\extensions\DSKWRK.vscode-generate-getter-setter-0.4.2\out\src\bulb.js:7:16)
    at c:\Program Files (x86)\Microsoft VS Code Insiders\resources\app\out\vs\workbench\node\extensionHostProcess.js:23:353536
    at c:\Program Files (x86)\Microsoft VS Code Insiders\resources\app\out\vs\workbench\node\extensionHostProcess.js:23:63025
    at new n.Class.derive._oncancel (c:\Program Files (x86)\Microsoft VS Code Insiders\resources\app\out\vs\workbench\node\extensionHostProcess.js:23:48235)
    at Object.t.asWinJsPromise (c:\Program Files (x86)\Microsoft VS Code Insiders\resources\app\out\vs\workbench\node\extensionHostProcess.js:23:62988)
    at e.provideCodeActions (c:\Program Files (x86)\Microsoft VS Code Insiders\resources\app\out\vs\workbench\node\extensionHostProcess.js:23:353490)
    at c:\Program Files (x86)\Microsoft VS Code Insiders\resources\app\out\vs\workbench\node\extensionHostProcess.js:23:363339
    at t._withAdapter (c:\Program Files (x86)\Microsoft VS Code Insiders\resources\app\out\vs\workbench\node\extensionHostProcess.js:23:359903)
```
produced when loading `vscode-icons` project.
The crash is caused because `containsItem` is called before the `constructor` calls `refreshExports`.