### PR TITLE
Fixed issues working with .d.ts. files from node_modules folder

### DIFF
--- a/src/bulb.ts
+++ b/src/bulb.ts
@@ -1,22 +1,30 @@
 import { DefinitionProvider } from './provider';
 import * as vscode from 'vscode';
+import { IExport, exportListContainsItem } from "./import";
 
 export class CompleteActionProvider implements vscode.CodeActionProvider {
-    public provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.Command[]> {
-        return new Promise((resolve, reject) => {
-            // optimizeImports(DefinitionProvider.instance.cachedExports, pickedItem.label);
+
+    public async provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): Promise<vscode.Command[]> {
+
+        try {
             const keyword = document.getText(range);
-            if (DefinitionProvider.instance.containsItem(keyword)) {
-                resolve([
+
+            const cachedExports: IExport[] = await DefinitionProvider.instance.getCachedExportsAsync();
+
+            if (exportListContainsItem(cachedExports, keyword)) {
+                return [
                     {
                         arguments: [keyword],
                         command: 'genGetSet.addImport',
                         title: 'Add import for ' + keyword
                     }
-                ]);
-            } else {
-                resolve([]);
+                ];
             }
-        });
+
+        } catch (err) {
+
+        }
+        
+        return [];
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "outDir": "out",
         "noLib": true,
         "sourceMap": true,


### PR DESCRIPTION
I found that your addin was not working for my compiled Typescript libraries where the output had been placed in the node_modules folder.

Debugging the code, I found and fixed the following issues:
1) Code that determined if a folder contained "test" or other text tested the full folder path and not just the part of the path within the node_modules folder
2) This code also only looked to see if the folder started with the name. 
3) The addin did not work with a node module that is a raw library.  It only worked if it found an index.d.ts or [libraryName].d.ts file in the folder.  I modified this to work if these were not found.  I don't think it will work properly if those files are found but those do not refer to the exported type.
4) At least one place where vscode expected a promise to evaluate the data, the extension just threw and rejected the operation.  Modified this code to wait to fulfill the promise until the exports were obtained.
5) Switched to ES6 in order to use the less error prone async coding model.

I believe I have fixed these issues with minimal to zero side effects.  