### PR TITLE
Add getter/setter generation from private constructor parameters

### DIFF
--- a/src/getset.ts
+++ b/src/getset.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { Variable } from './variable';
 import { findCtorPrivateParams } from './regexutil';
 
 export enum EType {
@@ -132,12 +133,12 @@ export function generateClassesList(type: EType): IClass[] {
             let _class = getClass(classes, brackets.name);
             const matches = {
                 privateDef: line.text.match(matchers.privateDef),
-                ctorMatches: findCtorPrivateParams(line.text),
+                ctorParams: findCtorPrivateParams(line.text),
                 getMethod: line.text.match(matchers.getMethod),
                 setMethod: line.text.match(matchers.setMethod)
             };
             if (_class &&
-                (matches.getMethod || matches.privateDef || matches.setMethod || matches.ctorMatches)) {
+                (matches.getMethod || matches.privateDef || matches.setMethod || matches.ctorParams)) {
                 // push the found items into the approriate containers
                 if (matches.privateDef) {
                     _class.vars.push({
@@ -147,12 +148,12 @@ export function generateClassesList(type: EType): IClass[] {
                     });
                 }
                 // add the private constructor parameters
-                if (matches.ctorMatches.length !== 0) {
-                    for (const match of matches.ctorMatches) {
+                if (matches.ctorParams.length !== 0) {
+                    for (const param of matches.ctorParams) {
                         _class.vars.push({
-                            name: match[2],
-                            figure: publicName(match[2]),
-                            typeName: match[3]
+                            name: param.name,
+                            figure: publicName(param.name),
+                            typeName: param.type
                         });
                     }
                 }

--- a/src/regexutil.ts
+++ b/src/regexutil.ts
@@ -2,7 +2,7 @@ import { Variable } from './variable';
 
 const matchers = {
     ctorDef: /\s*constructor\(\s*([^)]+?)\s*\)/,
-    ctorParam: /(?:public)?(private)?\s*([a-zA-Z_$][\w$]+)\s*\??:\s*([\.\w$]+<(?:[\.\w$\s]+,?)+>|[\.\[\]\w$]+)[^,]*,?\s*/y,
+    ctorParam: /(?:public)?(private)?\s*([a-zA-Z_$][\w$]+)\s*\??:\s*([\.\w$]+<(?:[\.\[\]\w$\s]+,?)+>|[\.\[\]\w$]+)[^,]*,?\s*/y,
 };
 
 /**

--- a/src/regexutil.ts
+++ b/src/regexutil.ts
@@ -1,0 +1,29 @@
+const matchers = {
+    ctorDef: /\s*constructor\(\s*([^)]+?)\s*\)/,
+    ctorParam: /(?:public)?(private)?\s*([a-zA-Z_$][\w$]*)\s*:\s*([^\s,]+),?\s*/y,
+};
+
+/**
+ * Finds private constructor parameters and returns them as {@link RegExpMatchArray[]}.
+ * The groups of the returned matches is:
+ *      0: full match
+ *      1: private
+ *      2: name
+ *      3: type
+ * @param line The line of text in which to try to find private constructor parameters.
+ */
+export function findCtorPrivateParams(line: string): RegExpMatchArray[] {
+    const params: RegExpMatchArray[] = [];
+    let ctor: RegExpMatchArray;
+    // First match the constructor, then match each param
+    if (ctor = line.match(matchers.ctorDef)) {
+        let param: RegExpMatchArray;
+        while (param = ctor[1].match(matchers.ctorParam)) {
+            // Check if the param is private
+            if (param[1]) {
+                params.push(param);
+            }
+        }
+    }
+    return params;
+}

--- a/src/regexutil.ts
+++ b/src/regexutil.ts
@@ -1,6 +1,8 @@
+import { Variable } from './variable';
+
 const matchers = {
     ctorDef: /\s*constructor\(\s*([^)]+?)\s*\)/,
-    ctorParam: /(?:public)?(private)?\s*([a-zA-Z_$][\w$]*)\s*:\s*([^\s,]+),?\s*/y,
+    ctorParam: /(?:public)?(private)?\s*([a-zA-Z_$][\w$]+)\s*:\s*((?:[\.<\w$\s]+[,>])+|[\.\w$\s]+),?\s*/y,
 };
 
 /**
@@ -12,8 +14,8 @@ const matchers = {
  *      3: type
  * @param line The line of text in which to try to find private constructor parameters.
  */
-export function findCtorPrivateParams(line: string): RegExpMatchArray[] {
-    const params: RegExpMatchArray[] = [];
+export function findCtorPrivateParams(line: string): Variable[] {
+    const params: Variable[] = [];
     let ctor: RegExpMatchArray;
     // First match the constructor, then match each param
     if (ctor = line.match(matchers.ctorDef)) {
@@ -21,7 +23,12 @@ export function findCtorPrivateParams(line: string): RegExpMatchArray[] {
         while (param = ctor[1].match(matchers.ctorParam)) {
             // Check if the param is private
             if (param[1]) {
-                params.push(param);
+                // The regex is not great and leaves a trailing comma on non-generic types
+                let type = param[3];
+                if (type.endsWith(',')) {
+                    type = type.substr(0, type.length - 1);
+                }
+                params.push(new Variable(param[2], type));
             }
         }
     }

--- a/src/regexutil.ts
+++ b/src/regexutil.ts
@@ -2,16 +2,11 @@ import { Variable } from './variable';
 
 const matchers = {
     ctorDef: /\s*constructor\(\s*([^)]+?)\s*\)/,
-    ctorParam: /(?:public)?(private)?\s*([a-zA-Z_$][\w$]+)\s*:\s*((?:[\.<\w$\s]+[,>])+|[\.\w$\s]+),?\s*/y,
+    ctorParam: /(?:public)?(private)?\s*([a-zA-Z_$][\w$]+)\s*\??:\s*([\.\w$]+<(?:[\.\w$\s]+,?)+>|[\.\[\]\w$]+)[^,]*,?\s*/y,
 };
 
 /**
- * Finds private constructor parameters and returns them as {@link RegExpMatchArray[]}.
- * The groups of the returned matches is:
- *      0: full match
- *      1: private
- *      2: name
- *      3: type
+ * Finds private constructor parameters and returns them as {@link Variable[]}.
  * @param line The line of text in which to try to find private constructor parameters.
  */
 export function findCtorPrivateParams(line: string): Variable[] {
@@ -23,12 +18,7 @@ export function findCtorPrivateParams(line: string): Variable[] {
         while (param = ctor[1].match(matchers.ctorParam)) {
             // Check if the param is private
             if (param[1]) {
-                // The regex is not great and leaves a trailing comma on non-generic types
-                let type = param[3];
-                if (type.endsWith(',')) {
-                    type = type.substr(0, type.length - 1);
-                }
-                params.push(new Variable(param[2], type));
+                params.push(new Variable(param[2], param[3]));
             }
         }
     }

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -1,0 +1,21 @@
+export class Variable {
+    constructor(private _name: string, private _type: string) {
+
+    }
+
+    public get name(): string {
+        return this._name;
+    }
+
+    public set name(value: string) {
+        this._name = value;
+    }
+
+    public get type(): string {
+        return this._type;
+    }
+
+    public set type(value: string) {
+        this._type = value;
+    }
+}

--- a/test/regexutil.test.ts
+++ b/test/regexutil.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+
+import * as regexutil from '../src/regexutil';
+
+suite("Regex Util Constructor Tests", () => {
+
+    test("Does match private params in constructor", () => {
+        const matches = regexutil.findCtorPrivateParams("constructor(private _name: string, private _age: number, _gender: string)");
+        assert.equal(2, matches.length);
+        assert.equal("_name", matches[0][2]);
+        assert.equal("string", matches[0][3]);
+        assert.equal("_age", matches[1][2]);
+        assert.equal("number", matches[1][3]);
+    });
+
+    test("Does ignore public and default params", () => {
+        const matches = regexutil.findCtorPrivateParams("constructor(public _name: string, private _age: number, _gender: string)");
+        assert.equal(1, matches.length);
+        assert.equal("_age", matches[0][2]);
+        assert.equal("number", matches[0][3]);
+    });
+
+    test("Does match private params after public and default params", () => {
+        const matches = regexutil.findCtorPrivateParams("constructor(public test: boolean, private _name: string, _gender: string, private _age: number)");
+        assert.equal(2, matches.length);
+        assert.equal("_name", matches[0][2]);
+        assert.equal("string", matches[0][3]);
+        assert.equal("_age", matches[1][2]);
+        assert.equal("number", matches[1][3]);
+    });
+
+    test("Does not match if not constructor", () => {
+        const matches = regexutil.findCtorPrivateParams("myMethod(private _name: string, private _age: number)");
+        assert.equal(0, matches.length);
+    });
+
+    test("Can match zero private params in constructor", () => {
+        const matches = regexutil.findCtorPrivateParams("constructor(name: string, age: number)");
+        assert.equal(0, matches.length);
+    });
+
+    test("Does not match if empty constructor", () => {
+        const matches = regexutil.findCtorPrivateParams("constructor()");
+        assert.equal(0, matches.length);
+    });
+
+});

--- a/test/regexutil.test.ts
+++ b/test/regexutil.test.ts
@@ -30,12 +30,12 @@ suite("Regex Util Constructor Tests", () => {
     });
 
     test("Can match generic types with more than one argument", () => {
-        const matches = regexutil.findCtorPrivateParams("constructor(private _test1: Type<string, number>, private _test2: Int<First, Second, Third>)");
+        const matches = regexutil.findCtorPrivateParams("constructor(private _test1: Type<string, number>, private _test2: Int<First, Second[], Third>)");
         assert.equal(2, matches.length);
         assert.equal("_test1", matches[0].name);
         assert.equal("Type<string, number>", matches[0].type);
         assert.equal("_test2", matches[1].name);
-        assert.equal("Int<First, Second, Third>", matches[1].type);
+        assert.equal("Int<First, Second[], Third>", matches[1].type);
     });
 
     test("Can match params with default value", () => {

--- a/test/regexutil.test.ts
+++ b/test/regexutil.test.ts
@@ -7,26 +7,35 @@ suite("Regex Util Constructor Tests", () => {
     test("Does match private params in constructor", () => {
         const matches = regexutil.findCtorPrivateParams("constructor(private _name: string, private _age: number, _gender: string)");
         assert.equal(2, matches.length);
-        assert.equal("_name", matches[0][2]);
-        assert.equal("string", matches[0][3]);
-        assert.equal("_age", matches[1][2]);
-        assert.equal("number", matches[1][3]);
+        assert.equal("_name", matches[0].name);
+        assert.equal("string", matches[0].type);
+        assert.equal("_age", matches[1].name);
+        assert.equal("number", matches[1].type);
     });
 
     test("Does ignore public and default params", () => {
         const matches = regexutil.findCtorPrivateParams("constructor(public _name: string, private _age: number, _gender: string)");
         assert.equal(1, matches.length);
-        assert.equal("_age", matches[0][2]);
-        assert.equal("number", matches[0][3]);
+        assert.equal("_age", matches[0].name);
+        assert.equal("number", matches[0].type);
     });
 
     test("Does match private params after public and default params", () => {
         const matches = regexutil.findCtorPrivateParams("constructor(public test: boolean, private _name: string, _gender: string, private _age: number)");
         assert.equal(2, matches.length);
-        assert.equal("_name", matches[0][2]);
-        assert.equal("string", matches[0][3]);
-        assert.equal("_age", matches[1][2]);
-        assert.equal("number", matches[1][3]);
+        assert.equal("_name", matches[0].name);
+        assert.equal("string", matches[0].type);
+        assert.equal("_age", matches[1].name);
+        assert.equal("number", matches[1].type);
+    });
+
+    test("Can match generic types with more than one argument", () => {
+        const matches = regexutil.findCtorPrivateParams("constructor(private _test1: Type<string, number>, private _test2: Int<First, Second, Third>)");
+        assert.equal(2, matches.length);
+        assert.equal("_test1", matches[0].name);
+        assert.equal("Type<string, number>", matches[0].type);
+        assert.equal("_test2", matches[1].name);
+        assert.equal("Int<First, Second, Third>", matches[1].type);
     });
 
     test("Does not match if not constructor", () => {

--- a/test/regexutil.test.ts
+++ b/test/regexutil.test.ts
@@ -38,6 +38,15 @@ suite("Regex Util Constructor Tests", () => {
         assert.equal("Int<First, Second, Third>", matches[1].type);
     });
 
+    test("Can match params with default value", () => {
+        const matches = regexutil.findCtorPrivateParams("constructor(private _test1: string = \"test1\", variable: string = 'abc',  private _test2: number = 7)");
+        assert.equal(2, matches.length);
+        assert.equal("_test1", matches[0].name);
+        assert.equal("string", matches[0].type);
+        assert.equal("_test2", matches[1].name);
+        assert.equal("number", matches[1].type);
+    });
+
     test("Does not match if not constructor", () => {
         const matches = regexutil.findCtorPrivateParams("myMethod(private _name: string, private _age: number)");
         assert.equal(0, matches.length);


### PR DESCRIPTION
This adds getter/setter generation from private constructor parameters. It works similarly to the existing generation. It only generates for parameters that are private and have a type that is not a nested generic. It is also able to handle optional and default parameters.
There are tests, and the matching method is in the regexutil file since it only makes sense to export a public-facing method (which is needed for testing).
The constructor signature must be on a single line.
Also, resolves #60 .